### PR TITLE
Create label-sponssors.yml

### DIFF
--- a/.github/.github/workflows/label-sponssors.yml
+++ b/.github/.github/workflows/label-sponssors.yml
@@ -1,0 +1,16 @@
+name: Label sponsors
+
+on:
+  pull_request:
+    types: [opened]
+  issues:
+    types: [opened]
+
+jobs:
+  build:
+    name: is-sponsor-label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JasonEtco/is-sponsor-label-action@v2.0.0  # Using the latest version (v2.0.0)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Auth token to interact with the repo


### PR DESCRIPTION
### **User description**
This pull request introduces a new GitHub Actions workflow to automatically label sponsors when a pull request or issue is opened.

* Added new GitHub Actions workflow file `.github/.github/workflows/label-sponssors.yml` to label sponsors on pull request and issue creation.


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Introduced a new GitHub Actions workflow to label sponsors.

- Configured the workflow to trigger on PR and issue creation.

- Utilized the `is-sponsor-label-action` GitHub Action for labeling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>label-sponssors.yml</strong><dd><code>Add workflow to label sponsors on PR/issues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/.github/workflows/label-sponssors.yml

<li>Added a new GitHub Actions workflow file.<br> <li> Configured triggers for pull requests and issues.<br> <li> Integrated <code>is-sponsor-label-action</code> for sponsor labeling.


</details>


  </td>
  <td><a href="https://github.com/canstralian/My-Python-Project-Template/pull/6/files#diff-5da7ffecba259e5ed306c603098d2079d46cd23adcb34886708388cc07f951d8">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced automated sponsor labeling for pull requests and issues, ensuring contributions are quickly and clearly marked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->